### PR TITLE
[feat ] More rakeable API for truck runner

### DIFF
--- a/lib/truck.rb
+++ b/lib/truck.rb
@@ -5,18 +5,30 @@ require 'truck/version'
 module Truck
   # Box to put the run instructions in
   class Runner
+    attr_reader :transactions, :events, :unmatched_transactions
+    def initialize
+      @transactions = Transactions.new
+      @events = Events.new
+    end
+
+    def collect_unmatched_transactions
+      transactions.load
+      transactions.build_set
+
+      events.load
+      events.build_set
+
+      @unmatched_ts = transactions.set - events.set
+    end
+
+    def fetch_transaction_data(transaction_ids)
+      transactions.find(transaction_ids)
+    end
+
     def run
-      txs = Transactions.new
-      txs.load
-      txs.build_set
-
-      evs = Events.new
-      evs.load
-      evs.build_set
-
-      unmatched_ts = txs.set - evs.set
-      return print "No missing transactions" unless unmatched_ts
-      transaction_data = txs.find(unmatched_ts)
+      collect_unmatched_transactions
+      return print 'No missing transactions' if unmatched_ts.empty?
+      transaction_data = transactions.find(unmatched_ts)
       write(transaction_data.map { |row| [row['id'], row['created_at']] })
     end
 

--- a/lib/truck.rb
+++ b/lib/truck.rb
@@ -18,7 +18,7 @@ module Truck
       events.load
       events.build_set
 
-      @unmatched_ts = transactions.set - events.set
+      @unmatched_transactions = transactions.set - events.set
     end
 
     def fetch_transaction_data(transaction_ids)
@@ -27,8 +27,8 @@ module Truck
 
     def run
       collect_unmatched_transactions
-      return print 'No missing transactions' if unmatched_ts.empty?
-      transaction_data = transactions.find(unmatched_ts)
+      return print 'No missing transactions' if unmatched_transactions.empty?
+      transaction_data = transactions.find(unmatched_transactions)
       write(transaction_data.map { |row| [row['id'], row['created_at']] })
     end
 

--- a/lib/truck.rb
+++ b/lib/truck.rb
@@ -21,10 +21,6 @@ module Truck
       @unmatched_transactions = transactions.set - events.set
     end
 
-    def fetch_transaction_data(transaction_ids)
-      transactions.find(transaction_ids)
-    end
-
     def run
       collect_unmatched_transactions
       return print 'No missing transactions' if unmatched_transactions.empty?


### PR DESCRIPTION
@hatchloyalty/platform 

Make the set of unmatched transaction IDs available via an accessable attribute on the Runner, so we can use that list to generate synthetic events in a rake task