### PR TITLE
Pick up enrollment_completion loyalty events

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    truck (0.2.0)
+    truck (0.2.1)
       dotenv (>= 1.0.0, < 3)
       pg (>= 0.18, < 2)
       sequel (>= 5, < 6)

--- a/lib/truck/dto/events.rb
+++ b/lib/truck/dto/events.rb
@@ -15,7 +15,11 @@ module Truck
       end
 
       def loyalty_events
-        time_scoped.exclude(event_type: %w[transactions loyalty_events memberships])
+        time_scoped.where(event_type: %w[profile_completion
+          wheel_spin
+          additional_questions
+          enrollment_completion
+        ])
       end
 
       def membership_create_events
@@ -39,7 +43,6 @@ module Truck
           loyalty_event = context.find do |resource|
             resource[:type] == 'loyalty_events'
           end
-          p row if loyalty_event.nil?
           loyalty_event[:id]
         end
       end

--- a/lib/truck/dto/events.rb
+++ b/lib/truck/dto/events.rb
@@ -15,9 +15,7 @@ module Truck
       end
 
       def loyalty_events
-        time_scoped.where(event_type: %w[profile_completion
-          wheel_spin
-          additional_questions])
+        time_scoped.exclude(event_type: %w[transactions loyalty_events memberships])
       end
 
       def membership_create_events
@@ -41,6 +39,7 @@ module Truck
           loyalty_event = context.find do |resource|
             resource[:type] == 'loyalty_events'
           end
+          p row if loyalty_event.nil?
           loyalty_event[:id]
         end
       end

--- a/lib/truck/version.rb
+++ b/lib/truck/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Truck
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end


### PR DESCRIPTION
@hatchloyalty/platform 

While running in hatch, I found that some loyalty events weren't being picked up because of the specific query. I wasn't aware that we had more loyalty events in some environments, so this adds one more.

I checked droptank and murphy for more sneaky events but none more appear, this was a hatch-only thing it seems.